### PR TITLE
Add tldextract to deps.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if not sys.version_info[0] == 3:
 import re
 from setuptools import find_packages, setup
 
-dependencies = ['click', 'requests']
+dependencies = ['click', 'requests', 'tldextract']
 
 version = re.search(
     '^__version__\s*=\s*"(.*)"',


### PR DESCRIPTION
I was getting ImportError when running `dnsgate`.

```
# /usr/local/bin/dnsgate 
Traceback (most recent call last):
  File "/usr/local/bin/dnsgate", line 9, in <module>
    load_entry_point('dnsgate==0.0.1', 'console_scripts', 'dnsgate')()
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2476, in load_entry_point
    return ep.load()
  File "/usr/lib/python3/dist-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/local/lib/python3.4/dist-packages/dnsgate-0.0.1-py3.4.egg/dnsgate/dnsgate.py", line 24, in <module>
    import tldextract
ImportError: No module named 'tldextract'
```
